### PR TITLE
add support for fetching author's url in pull requests

### DIFF
--- a/src/github_graphql/mod.rs
+++ b/src/github_graphql/mod.rs
@@ -1,6 +1,5 @@
 use ::reqwest::blocking::Client;
 use graphql_client::{reqwest::post_graphql_blocking, GraphQLQuery};
-use log::info;
 use reqwest::header::{HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
 
 use crate::github_graphql;
@@ -21,8 +20,9 @@ struct Label {
   name: String,
 }
 
-struct Author {
-  login: String,
+pub struct Author {
+  pub login: String,
+  pub url: String,
 }
 
 pub struct PullRequest {
@@ -31,7 +31,7 @@ pub struct PullRequest {
   pub url: URI,
   pub number: i64,
   labels: Vec<Label>,
-  author: Author,
+  pub author: Author,
 }
 
 fn set_headers(token: &str) -> ::reqwest::header::HeaderMap {
@@ -64,13 +64,7 @@ pub async fn get_pull_requests(
   .unwrap();
   let response_data: milestone_query::ResponseData =
     response_body.data.expect("missing response data");
-  info!("{:?}", response_data);
-  println!("{:?}", response_data);
   let pull_requests = map_pull_request(&response_data);
-  pull_requests.iter().for_each(|pr| {
-    println!("{:?}", pr.title);
-    println!("{:?}", pr.url);
-  });
   Ok(pull_requests)
 }
 
@@ -98,6 +92,7 @@ fn map_pull_request(response_data: &milestone_query::ResponseData) -> Vec<PullRe
       labels: get_labels(pr),
       author: Author {
         login: pr.as_ref().unwrap().author.as_ref().unwrap().login.clone(),
+        url: pr.as_ref().unwrap().author.as_ref().unwrap().url.clone(),
       },
     })
     .collect::<Vec<PullRequest>>()

--- a/src/github_graphql/query.graphql
+++ b/src/github_graphql/query.graphql
@@ -20,6 +20,7 @@ query MilestoneQuery($owner: String!, $name: String!, $milestone: String!) {
             author {
               __typename
               login
+              url
             }
           }
         }

--- a/templates/changelog.md
+++ b/templates/changelog.md
@@ -1,3 +1,7 @@
 # {{ owner}}/{{ project }} - {{ release }} ({{date}}) 
 
 {{ pull_requests }}
+
+### Contributors
+
+{{ contributors }}


### PR DESCRIPTION
added support for fetching the author's url in pull requests in order to properly format the contributors list in the changelog. this was accomplished by updating the pullrequest, author, and query.graphql structs, adding the url field to the author struct and the query, and calling the field in the map_pull_request function. finally, a new format_contributors_to_md function was added to the main.rs file in order to properly format the contributors in the changelog.