### PR TITLE
update pull request labels and contributors in changelog

### DIFF
--- a/src/github_graphql/mod.rs
+++ b/src/github_graphql/mod.rs
@@ -2,8 +2,7 @@ use ::reqwest::blocking::Client;
 use graphql_client::{reqwest::post_graphql_blocking, GraphQLQuery};
 use reqwest::header::{HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
 
-use crate::github_graphql;
-use github_graphql::milestone_query::MilestoneQueryRepositoryMilestonesNodesPullRequestsNodes;
+use milestone_query::MilestoneQueryRepositoryMilestonesNodesPullRequestsNodes;
 
 #[allow(clippy::upper_case_acronyms)]
 type URI = String;
@@ -16,8 +15,8 @@ type URI = String;
 )]
 struct MilestoneQuery;
 
-struct Label {
-  name: String,
+pub struct Label {
+  pub name: String,
 }
 
 pub struct Author {
@@ -30,7 +29,7 @@ pub struct PullRequest {
   pub title: String,
   pub url: URI,
   pub number: i64,
-  labels: Vec<Label>,
+  pub labels: Vec<Label>,
   pub author: Author,
 }
 
@@ -47,7 +46,7 @@ pub async fn get_pull_requests(
   name: &str,
   milestone: &str,
   token: &str,
-) -> Result<Vec<github_graphql::PullRequest>, Box<dyn std::error::Error>> {
+) -> Result<Vec<PullRequest>, Box<dyn std::error::Error>> {
   let headers = set_headers(token);
   let client = Client::builder().default_headers(headers).build()?;
   // should be a parameter

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,10 +29,10 @@ struct Changelog {
   owner: String,
   project: String,
   release: String,
-  github_token: String,
   date: NaiveDate,
   pull_requests: String,
   contributors: String,
+  labels: String,
 }
 
 // This function does not consume the arguments
@@ -49,14 +49,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
   let pull_requests = block_on(future);
   let pr_markdown = format_pull_requests_to_md(&pull_requests);
   let contributors = format_contributors_to_md(&pull_requests);
+  let labels = format_labels_to_md(&pull_requests);
   let changelog = Changelog {
     owner: args.owner,
     project: args.project,
     release: args.release,
-    github_token: args.github_token,
     date: NaiveDate::from_ymd_opt(2021, 1, 1).unwrap(),
     pull_requests: pr_markdown,
     contributors,
+    labels,
   };
 
   println!("{}", changelog.render().unwrap());
@@ -106,6 +107,26 @@ fn format_contributors_to_md(
         ));
       });
       contributors.to_string()
+    }
+    Err(e) => format!("Error: {}", e),
+  }
+}
+
+fn format_labels_to_md(
+  pull_requests: &Result<
+    std::vec::Vec<github_graphql::PullRequest>,
+    std::boxed::Box<dyn std::error::Error>,
+  >,
+) -> String {
+  match pull_requests {
+    Ok(pull_requests) => {
+      let mut labels = String::new();
+      pull_requests.iter().for_each(|pr| {
+        pr.labels.iter().for_each(|label| {
+          labels.push_str(&format!("- {}\n", label.name,));
+        });
+      });
+      labels.to_string()
     }
     Err(e) => format!("Error: {}", e),
   }

--- a/templates/changelog.md
+++ b/templates/changelog.md
@@ -1,7 +1,11 @@
-# {{ owner}}/{{ project }} - {{ release }} ({{date}}) 
+# {{ owner }}/{{ project }} - {{ release }} ({{ date }}) 
 
 {{ pull_requests }}
 
 ### Contributors
 
 {{ contributors }}
+
+### Tags
+
+{{ labels }}


### PR DESCRIPTION
updates the pull request labels and contributors in the changelog. the changes made to the source code include:

- removing the use of the `github_graphql` crate in the `mod.rs` crate.
- making the `label` struct public in the `mod.rs` crate.
- adding a `labels` field to the `pullrequest` struct in the `mod.rs` crate.
- adding a function `format_labels_to_md()` to the `main.rs` crate.
- updating the `changelog` struct in the `main.rs` crate.
- updating the `main()` function in the `main.rs` crate.
- updating the `templates/changelog.md` template.

this commit will ensure that the labels and contributors are properly included in the changelog when generating the markdown.