### PR TITLE
move formatting functions to github_graphql module

### DIFF
--- a/src/github_graphql/mod.rs
+++ b/src/github_graphql/mod.rs
@@ -97,6 +97,48 @@ fn map_pull_request(response_data: &milestone_query::ResponseData) -> Vec<PullRe
     .collect::<Vec<PullRequest>>()
 }
 
+pub fn format_pull_requests_to_md(
+  pull_requests: &Result<std::vec::Vec<PullRequest>, std::boxed::Box<dyn std::error::Error>>,
+) -> String {
+  match pull_requests {
+    Ok(pull_requests) => {
+      let mut pull_requests_md = String::new();
+      pull_requests.iter().for_each(|pr| {
+        pull_requests_md.push_str(&format!(
+          "- [{}]({})\n",
+          pr.title,
+          pr.url.to_string().replace("api.", "").replace("repos/", "")
+        ));
+      });
+      pull_requests_md.to_string()
+    }
+    Err(e) => format!("Error: {}", e),
+  }
+}
+
+pub fn format_contributors_to_md(
+  pull_requests: &Result<std::vec::Vec<PullRequest>, std::boxed::Box<dyn std::error::Error>>,
+) -> String {
+  match pull_requests {
+    Ok(pull_requests) => {
+      let mut contributors = String::new();
+      pull_requests.iter().for_each(|pr| {
+        contributors.push_str(&format!(
+          "- [{}]({})\n",
+          pr.author.login,
+          pr.author
+            .url
+            .to_string()
+            .replace("api.", "")
+            .replace("users/", "")
+        ));
+      });
+      contributors.to_string()
+    }
+    Err(e) => format!("Error: {}", e),
+  }
+}
+
 fn get_labels(pr: &Option<MilestoneQueryRepositoryMilestonesNodesPullRequestsNodes>) -> Vec<Label> {
   pr.as_ref()
     .and_then(|pr| pr.labels.as_ref())
@@ -111,4 +153,21 @@ fn get_labels(pr: &Option<MilestoneQueryRepositoryMilestonesNodesPullRequestsNod
         .collect::<Vec<Label>>()
     })
     .unwrap_or_else(Vec::new)
+}
+
+pub fn format_labels_to_md(
+  pull_requests: &Result<std::vec::Vec<PullRequest>, std::boxed::Box<dyn std::error::Error>>,
+) -> String {
+  match pull_requests {
+    Ok(pull_requests) => {
+      let mut labels = String::new();
+      pull_requests.iter().for_each(|pr| {
+        pr.labels.iter().for_each(|label| {
+          labels.push_str(&format!("- {}\n", label.name,));
+        });
+      });
+      labels.to_string()
+    }
+    Err(e) => format!("Error: {}", e),
+  }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,6 @@ struct Changelog {
   labels: String,
 }
 
-// This function does not consume the arguments
 fn main() -> Result<(), Box<dyn std::error::Error>> {
   let args: Args = Args::parse();
 
@@ -47,9 +46,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
   );
 
   let pull_requests = block_on(future);
-  let pr_markdown = format_pull_requests_to_md(&pull_requests);
-  let contributors = format_contributors_to_md(&pull_requests);
-  let labels = format_labels_to_md(&pull_requests);
+  let pr_markdown = github_graphql::format_pull_requests_to_md(&pull_requests);
+  let contributors = github_graphql::format_contributors_to_md(&pull_requests);
+  let labels = github_graphql::format_labels_to_md(&pull_requests);
   let changelog = Changelog {
     owner: args.owner,
     project: args.project,
@@ -62,72 +61,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
   println!("{}", changelog.render().unwrap());
   Ok(())
-}
-
-fn format_pull_requests_to_md(
-  pull_requests: &Result<
-    std::vec::Vec<github_graphql::PullRequest>,
-    std::boxed::Box<dyn std::error::Error>,
-  >,
-) -> String {
-  match pull_requests {
-    Ok(pull_requests) => {
-      let mut pull_requests_md = String::new();
-      pull_requests.iter().for_each(|pr| {
-        pull_requests_md.push_str(&format!(
-          "- [{}]({})\n",
-          pr.title,
-          pr.url.to_string().replace("api.", "").replace("repos/", "")
-        ));
-      });
-      pull_requests_md.to_string()
-    }
-    Err(e) => format!("Error: {}", e),
-  }
-}
-
-fn format_contributors_to_md(
-  pull_requests: &Result<
-    std::vec::Vec<github_graphql::PullRequest>,
-    std::boxed::Box<dyn std::error::Error>,
-  >,
-) -> String {
-  match pull_requests {
-    Ok(pull_requests) => {
-      let mut contributors = String::new();
-      pull_requests.iter().for_each(|pr| {
-        contributors.push_str(&format!(
-          "- [{}]({})\n",
-          pr.author.login,
-          pr.author
-            .url
-            .to_string()
-            .replace("api.", "")
-            .replace("users/", "")
-        ));
-      });
-      contributors.to_string()
-    }
-    Err(e) => format!("Error: {}", e),
-  }
-}
-
-fn format_labels_to_md(
-  pull_requests: &Result<
-    std::vec::Vec<github_graphql::PullRequest>,
-    std::boxed::Box<dyn std::error::Error>,
-  >,
-) -> String {
-  match pull_requests {
-    Ok(pull_requests) => {
-      let mut labels = String::new();
-      pull_requests.iter().for_each(|pr| {
-        pr.labels.iter().for_each(|label| {
-          labels.push_str(&format!("- {}\n", label.name,));
-        });
-      });
-      labels.to_string()
-    }
-    Err(e) => format!("Error: {}", e),
-  }
 }


### PR DESCRIPTION
moves the formatting functions `format_pull_requests_to_md`, `format_contributors_to_md` and `format_labels_to_md` from the `main.rs` file to the `github_graphql` module. this allows for the functions to be used in multiple locations.

the commit changes the files `src/github_graphql/mod.rs` and `src/main.rs` to move the functions from one to the other and adjust the calls accordingly. the diff shows the changes in both files.