### PR TITLE
fix to add the current date in new releases

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use askama::Template;
-use chrono::NaiveDate;
+use chrono::{NaiveDate, Utc};
 use clap::Parser;
 use futures::executor::block_on;
 
@@ -49,11 +49,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
   let pr_markdown = github_graphql::format_pull_requests_to_md(&pull_requests);
   let contributors = github_graphql::format_contributors_to_md(&pull_requests);
   let labels = github_graphql::format_labels_to_md(&pull_requests);
+  let today = Utc::now().date_naive();
   let changelog = Changelog {
     owner: args.owner,
     project: args.project,
     release: args.release,
-    date: NaiveDate::from_ymd_opt(2021, 1, 1).unwrap(),
+    date: today,
     pull_requests: pr_markdown,
     contributors,
     labels,


### PR DESCRIPTION
updates the changelog for a project with a new release. it changes the date in the changelog from a static value to today's date, and also adds the `utc` module to the imports.

```diff
diff --git a/src/main.rs b/src/main.rs
index a8a4fe70f03a..2f8e941b1e17 100644
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use askama::template;
-use chrono::naivedate;
+use chrono::{naivedate, utc};
 use clap::parser;
 use futures::executor::block_on;

@@ -49,11 +49,12 @@ fn main() -> result<(), box<dyn std::error::error>> {
   let pr_markdown = github_graphql::format_pull_requests_to_md(&pull_requests);
   let contributors = github_graphql::format_contributors_to_md(&pull_requests);
   let labels = github_graphql::format_labels_to_md(&pull_requests);
+  let today = utc::now().date_naive();
   let changelog = changelog {
     owner: args.owner,
     project: args.project,
     release: args.release,
-    date: naivedate::from_ymd_opt(2021, 1, 1).unwrap(),
+    date: today,
     pull_requests: pr_markdown,
     contributors,
     labels,
```

this change ensures that the changelog for the project always has the most up-to-date release date.