### PR TITLE
format contributors to markdown

### DIFF
--- a/src/github_graphql/mod.rs
+++ b/src/github_graphql/mod.rs
@@ -124,7 +124,7 @@ pub fn format_contributors_to_md(
       .iter()
       .map(|pr| {
         format!(
-          "- [{}]({})\n",
+          "- [@{}]({})\n",
           pr.author.login,
           pr.author
             .url

--- a/templates/example.md
+++ b/templates/example.md
@@ -13,13 +13,13 @@
 
 ### Contributors
 
-- [Enselic](https://github.com/Enselic)
-- [Enselic](https://github.com/Enselic)
-- [RalfJung](https://github.com/RalfJung)
-- [Trolldemorted](https://github.com/Trolldemorted)
-- [matthiaskrgr](https://github.com/matthiaskrgr)
-- [matthiaskrgr](https://github.com/matthiaskrgr)
-- [ttsugriy](https://github.com/ttsugriy)
-- [Kobzol](https://github.com/Kobzol)
-- [lnicola](https://github.com/lnicola)
-- [matthiaskrgr](https://github.com/matthiaskrgr)
+- [@Enselic](https://github.com/Enselic)
+- [@Enselic](https://github.com/Enselic)
+- [@RalfJung](https://github.com/RalfJung)
+- [@Trolldemorted](https://github.com/Trolldemorted)
+- [@matthiaskrgr](https://github.com/matthiaskrgr)
+- [@matthiaskrgr](https://github.com/matthiaskrgr)
+- [@ttsugriy](https://github.com/ttsugriy)
+- [@Kobzol](https://github.com/Kobzol)
+- [@lnicola](https://github.com/lnicola)
+- [@matthiaskrgr](https://github.com/matthiaskrgr)


### PR DESCRIPTION
adds `@` symbol before the contributors' usernames in the markdown template.

the changes are in the file `templates/example.md`, which has been updated to include `@` before usernames in the contributors section. for example, `- [enselic](https://github.com/enselic)` has been changed to `- [@enselic](https://github.com/enselic)`.