### PR TITLE
update main.rs to remove unnecessary result type

### DIFF
--- a/src/github_graphql/mod.rs
+++ b/src/github_graphql/mod.rs
@@ -1,8 +1,7 @@
 use ::reqwest::blocking::Client;
 use graphql_client::{reqwest::post_graphql_blocking, GraphQLQuery};
-use reqwest::header::{HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
-
 use milestone_query::MilestoneQueryRepositoryMilestonesNodesPullRequestsNodes;
+use reqwest::header::{HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
 
 #[allow(clippy::upper_case_acronyms)]
 type URI = String;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ struct Changelog {
   labels: String,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
   let args: Args = Args::parse();
 
   let future = github_graphql::get_pull_requests(
@@ -61,5 +61,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
   };
 
   println!("{}", changelog.render().unwrap());
-  Ok(())
 }


### PR DESCRIPTION
updates the `main.rs` file to remove the unnecessary `result` type and replace it with a `main()` function that returns nothing.

the changes made to the file are as follows:

- changed the `main()` function signature from `result<(), box<dyn std::error::error>>` to `main()`
- removed the call to `ok` at the end of the function

in addition to the changes in `main.rs`, this commit also updates the `github_graphql/mod.rs` file to add the `reqwest::header` module back in.