### PR TITLE
add env_logger to main.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +226,7 @@ dependencies = [
  "askama",
  "chrono",
  "clap",
+ "env_logger",
  "futures",
  "graphql_client",
  "log",
@@ -329,6 +339,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -621,6 +644,12 @@ checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -970,6 +999,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+
+[[package]]
 name = "reqwest"
 version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1222,15 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1471,6 +1538,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ serde_json = "1.0.104"
 serde = { version = "1.0.182", features = ["derive"]}
 log = "0.4.19"
 futures = "0.3.28"
+env_logger = "0.10.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,5 +64,5 @@ fn main() {
     contributors,
     labels,
   };
-  info!("changelog: {}", changelog.render().unwrap());
+  info!("{}", changelog.render().unwrap());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use askama::Template;
 use chrono::{NaiveDate, Utc};
 use clap::Parser;
+use env_logger::Builder;
 use futures::executor::block_on;
+use log::info;
 
 mod github_graphql;
 
@@ -35,16 +37,19 @@ struct Changelog {
   labels: String,
 }
 
-fn main() {
-  let args: Args = Args::parse();
+fn init_logger() {
+  Builder::new().filter(None, log::LevelFilter::Info).init();
+}
 
+fn main() {
+  init_logger();
+  let args: Args = Args::parse();
   let future = github_graphql::get_pull_requests(
     &args.owner,
     &args.project,
     &args.release,
     &args.github_token,
   );
-
   let pull_requests = block_on(future);
   let pr_markdown = github_graphql::format_pull_requests_to_md(&pull_requests);
   let contributors = github_graphql::format_contributors_to_md(&pull_requests);
@@ -59,6 +64,5 @@ fn main() {
     contributors,
     labels,
   };
-
-  println!("{}", changelog.render().unwrap());
+  info!("changelog: {}", changelog.render().unwrap());
 }


### PR DESCRIPTION
adds env_logger to the main.rs file to enable logging for the program. this includes adding the env_logger dependency to cargo.toml and adding the necessary initialization code to main.rs.

the diff shows the changes to cargo.lock and cargo.toml to add the env_logger dependency, as well as the changes to src/main.rs to include the initialization code.