### PR TITLE
refactor get_changelog_info to use async including prs, contributors …

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,7 @@ fn main() {
   logger::init();
   let args: Args = Args::parse();
   let pull_requests = github_graphql::fetch_pull_requests(&args);
-  let pr_markdown = github_graphql::format_pull_requests_to_md(&pull_requests);
-  let contributors = github_graphql::format_contributors_to_md(&pull_requests);
-  let labels = github_graphql::format_labels_to_md(&pull_requests);
+  let (pr_markdown, contributors, labels) = github_graphql::get_changelog_info(&pull_requests);
   let changelog = templates::create_changelog(&args, &pr_markdown, &contributors, &labels);
   logger::log_changelog(&changelog);
 }


### PR DESCRIPTION
…and labels

refactored the `get_changelog_info` function in `github_graphql/mod.rs` to use async instead of blocking. this refactor allows for improved performance and scalability when fetching pull request information.

```diff
diff --git a/src/github_graphql/mod.rs b/src/github_graphql/mod.rs
index fce1f915bb66..7b84ebf64d9a 100644
--- a/src/github_graphql/mod.rs
+++ b/src/github_graphql/mod.rs
@@ -122,13 +122,25 @@ fn get_labels(pr: &option<milestonequeryrepositorymilestonesnodespullrequestsnod
     .unwrap_or_else(vec::new)
 }

-pub fn format_pull_requests_to_md(pull_requests: &[pullrequest]) -> string {
+pub fn get_changelog_info(pull_requests: &[pullrequest]) -> (string, string, string) {
+  block_on(format_pull_requests_info(pull_requests))
+}
+
+pub async fn format_pull_requests_info(pull_requests: &[pullrequest]) -> (string, string, string) {
+  let pr_fut = format_pull_requests_to_md(pull_requests);
+  let contributors_fut = format_contributors_to_md(pull_requests);
+  let labels_fut = format_labels_to_md(pull_requests);
+  let (pr, contributors, labels) = join3(pr_fut, contributors_fut, labels_fut).await;
+  (pr, contributors, labels)
+}
+
+pub async fn format_pull_requests_to_md(pull_requests: &[pullrequest]) -> string {
   format_items_to_md(pull_requests, |pr| {
     format!("- [{}]({})\n", pr.title, format_url(pr.url.to_string()))
   })
 }

-pub fn format_contributors_to_md(pull_requests: &[pullrequest]) -> string {
+pub async fn format_contributors_to_md(pull_requests: &[pullrequest]) -> string {
   format_items_to_md(pull_requests, |pr| {
     format!(
       "- [@{}]({})\n",
@@ -138,7 +150,7 @@ pub fn format_contributors_to_md(pull_requests: &[pullrequest]) -> string {
   })
 }

-pub fn format_labels_to_md(pull_requests: &[pullrequest]) -> string {
+pub async fn format_labels_to_md(pull_requests: &[pullrequest]) -> string {
   format_items_to_md(pull_requests, |pr| {
     pr.labels
       .iter()
```

this commit refactors the `get_changelog_info` function to use async for improved performance and scalability when fetching pull request information.